### PR TITLE
feat(landing-pages): add landing pages manager and interceptors (issue #77)

### DIFF
--- a/assets/css/landing-pages-admin.css
+++ b/assets/css/landing-pages-admin.css
@@ -51,10 +51,10 @@
 }
 
 /* Top border card highlights based on type */
-.eo-lp-card.eo-status-coming-soon.active::before { background: #3b82f6; }
+.eo-lp-card.eo-status-coming-soon.active::before { background: #f59e0b; }
 .eo-lp-card.eo-status-maintenance.active::before { background: #d63638; }
 .eo-lp-card.eo-status-login.active::before { background: #06b6d4; }
-.eo-lp-card.eo-status-404.active::before { background: #f59e0b; }
+.eo-lp-card.eo-status-404.active::before { background: #3b82f6; }
 
 /* Card Header */
 .eo-lp-card-header {
@@ -75,9 +75,10 @@
 	color: #3b82f6;
 }
 
+.eo-lp-card.eo-status-coming-soon.active .eo-lp-card-icon { color: #f59e0b; }
 .eo-lp-card.eo-status-maintenance.active .eo-lp-card-icon { color: #d63638; }
 .eo-lp-card.eo-status-login.active .eo-lp-card-icon { color: #06b6d4; }
-.eo-lp-card.eo-status-404.active .eo-lp-card-icon { color: #f59e0b; }
+.eo-lp-card.eo-status-404.active .eo-lp-card-icon { color: #3b82f6; }
 
 /* iOS Switch Slider */
 .eo-lp-toggle-wrapper {
@@ -128,10 +129,10 @@
 	background-color: #10b981;
 }
 
-.eo-lp-card.eo-status-coming-soon input:checked + .eo-lp-slider { background-color: #3b82f6; }
+.eo-lp-card.eo-status-coming-soon input:checked + .eo-lp-slider { background-color: #f59e0b; }
 .eo-lp-card.eo-status-maintenance input:checked + .eo-lp-slider { background-color: #d63638; }
 .eo-lp-card.eo-status-login input:checked + .eo-lp-slider { background-color: #06b6d4; }
-.eo-lp-card.eo-status-404 input:checked + .eo-lp-slider { background-color: #f59e0b; }
+.eo-lp-card.eo-status-404 input:checked + .eo-lp-slider { background-color: #3b82f6; }
 
 .eo-lp-switch input:checked + .eo-lp-slider:before {
 	transform: translateX(20px);
@@ -148,10 +149,10 @@
 .eo-lp-toggle-label.active {
 	color: #10b981;
 }
-.eo-lp-card.eo-status-coming-soon .eo-lp-toggle-label.active { color: #3b82f6; }
+.eo-lp-card.eo-status-coming-soon .eo-lp-toggle-label.active { color: #f59e0b; }
 .eo-lp-card.eo-status-maintenance .eo-lp-toggle-label.active { color: #d63638; }
 .eo-lp-card.eo-status-login .eo-lp-toggle-label.active { color: #06b6d4; }
-.eo-lp-card.eo-status-404 .eo-lp-toggle-label.active { color: #f59e0b; }
+.eo-lp-card.eo-status-404 .eo-lp-toggle-label.active { color: #3b82f6; }
 
 /* Card Content */
 .eo-lp-card-body {

--- a/assets/css/landing-pages-admin.css
+++ b/assets/css/landing-pages-admin.css
@@ -302,6 +302,53 @@
 .eo-lp-color-picker-wrapper {
 	display: flex;
 	align-items: center;
+	background: #ffffff;
+	border: 1px solid #cbd5e1;
+	border-radius: 6px;
+	padding: 4px 10px;
+	max-width: 220px;
+	height: 40px;
+	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.02);
+	transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.eo-lp-color-picker-wrapper:focus-within {
+	border-color: #3b82f6;
+	box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.eo-lp-color-picker-wrapper input[type="color"] {
+	border: none;
+	width: 28px;
+	height: 28px;
+	border-radius: 50%;
+	cursor: pointer;
+	padding: 0;
+	background: none;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.eo-lp-color-picker-wrapper input[type="color"]::-webkit-color-swatch-wrapper {
+	padding: 0;
+}
+
+.eo-lp-color-picker-wrapper input[type="color"]::-webkit-color-swatch {
+	border: none;
+	border-radius: 50%;
+}
+
+.eo-lp-color-picker-wrapper input[type="text"] {
+	border: none !important;
+	background: transparent !important;
+	box-shadow: none !important;
+	margin-left: 8px !important;
+	font-family: monospace;
+	font-size: 13px;
+	width: 80px !important;
+	text-transform: uppercase;
+	color: #1e293b;
+	padding: 0 !important;
+	height: auto !important;
 }
 
 /* Form Footer */

--- a/assets/css/landing-pages-admin.css
+++ b/assets/css/landing-pages-admin.css
@@ -1,0 +1,335 @@
+/**
+ * Styles for EO Blocks - Landing Pages admin interface
+ */
+
+.eo-landing-pages-admin-wrapper {
+	max-width: 1200px;
+	margin: 20px auto 40px auto;
+}
+
+/* Card Grid */
+.eo-lp-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	gap: 24px;
+	margin-bottom: 30px;
+}
+
+/* Card Styling */
+.eo-lp-card {
+	background: #ffffff;
+	border: 1px solid #e2e8f0;
+	border-radius: 12px;
+	box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.02);
+	display: flex;
+	flex-direction: column;
+	padding: 24px;
+	transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+	position: relative;
+	overflow: hidden;
+}
+
+.eo-lp-card::before {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 4px;
+	background: #cbd5e1;
+	transition: background 0.25s ease;
+}
+
+.eo-lp-card.active::before {
+	background: #10b981; /* green indicator when active */
+}
+
+.eo-lp-card:hover {
+	transform: translateY(-4px);
+	box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+	border-color: #cbd5e1;
+}
+
+/* Top border card highlights based on type */
+.eo-lp-card.eo-status-coming-soon.active::before { background: #3b82f6; }
+.eo-lp-card.eo-status-maintenance.active::before { background: #d63638; }
+.eo-lp-card.eo-status-login.active::before { background: #06b6d4; }
+.eo-lp-card.eo-status-404.active::before { background: #f59e0b; }
+
+/* Card Header */
+.eo-lp-card-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 20px;
+}
+
+.eo-lp-card-icon {
+	font-size: 28px;
+	width: 28px;
+	height: 28px;
+	color: #64748b;
+}
+
+.eo-lp-card.active .eo-lp-card-icon {
+	color: #3b82f6;
+}
+
+.eo-lp-card.eo-status-maintenance.active .eo-lp-card-icon { color: #d63638; }
+.eo-lp-card.eo-status-login.active .eo-lp-card-icon { color: #06b6d4; }
+.eo-lp-card.eo-status-404.active .eo-lp-card-icon { color: #f59e0b; }
+
+/* iOS Switch Slider */
+.eo-lp-toggle-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.eo-lp-switch {
+	position: relative;
+	display: inline-block;
+	width: 44px;
+	height: 24px;
+}
+
+.eo-lp-switch input {
+	opacity: 0;
+	width: 0;
+	height: 0;
+}
+
+.eo-lp-slider {
+	position: absolute;
+	cursor: pointer;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: #cbd5e1;
+	transition: .3s;
+	border-radius: 24px;
+}
+
+.eo-lp-slider:before {
+	position: absolute;
+	content: "";
+	height: 18px;
+	width: 18px;
+	left: 3px;
+	bottom: 3px;
+	background-color: white;
+	transition: .3s;
+	border-radius: 50%;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.eo-lp-switch input:checked + .eo-lp-slider {
+	background-color: #10b981;
+}
+
+.eo-lp-card.eo-status-coming-soon input:checked + .eo-lp-slider { background-color: #3b82f6; }
+.eo-lp-card.eo-status-maintenance input:checked + .eo-lp-slider { background-color: #d63638; }
+.eo-lp-card.eo-status-login input:checked + .eo-lp-slider { background-color: #06b6d4; }
+.eo-lp-card.eo-status-404 input:checked + .eo-lp-slider { background-color: #f59e0b; }
+
+.eo-lp-switch input:checked + .eo-lp-slider:before {
+	transform: translateX(20px);
+}
+
+.eo-lp-toggle-label {
+	font-size: 10px;
+	font-weight: bold;
+	color: #64748b;
+	width: 50px;
+	transition: color 0.2s;
+}
+
+.eo-lp-toggle-label.active {
+	color: #10b981;
+}
+.eo-lp-card.eo-status-coming-soon .eo-lp-toggle-label.active { color: #3b82f6; }
+.eo-lp-card.eo-status-maintenance .eo-lp-toggle-label.active { color: #d63638; }
+.eo-lp-card.eo-status-login .eo-lp-toggle-label.active { color: #06b6d4; }
+.eo-lp-card.eo-status-404 .eo-lp-toggle-label.active { color: #f59e0b; }
+
+/* Card Content */
+.eo-lp-card-body {
+	flex: 1;
+	margin-bottom: 24px;
+}
+
+.eo-lp-card-title {
+	font-size: 16px;
+	font-weight: 700;
+	color: #1e293b;
+	margin: 0 0 10px 0 !important;
+}
+
+.eo-lp-card-desc {
+	font-size: 13px;
+	color: #64748b;
+	line-height: 1.5;
+	margin: 0;
+}
+
+/* Card Actions */
+.eo-lp-card-footer {
+	display: flex;
+	gap: 10px;
+}
+
+.eo-lp-card-footer .button {
+	flex: 1;
+	justify-content: center;
+	text-align: center;
+}
+
+/* Editor Panel */
+.eo-lp-editor-panel {
+	background: #ffffff;
+	border: 1px solid #ccd0d4;
+	border-radius: 12px;
+	box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.02);
+	margin-top: 30px;
+	overflow: hidden;
+	animation: slideDown 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.eo-lp-editor-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	background: #f8fafc;
+	border-bottom: 1px solid #e2e8f0;
+	padding: 18px 24px;
+}
+
+.eo-lp-editor-title {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 0 !important;
+	font-size: 18px;
+	font-weight: 700;
+	color: #1e293b;
+}
+
+.eo-lp-editor-icon {
+	font-size: 20px;
+	width: 20px;
+	height: 20px;
+	color: #475569;
+}
+
+.eo-lp-editor-close-btn {
+	background: none;
+	border: none;
+	font-size: 28px;
+	line-height: 1;
+	color: #94a3b8;
+	cursor: pointer;
+	padding: 0;
+	transition: color 0.2s;
+}
+
+.eo-lp-editor-close-btn:hover {
+	color: #475569;
+}
+
+/* Editor Grid */
+.eo-lp-editor-grid {
+	display: grid;
+	grid-template-columns: 2fr 1fr;
+	gap: 30px;
+	padding: 24px;
+}
+
+@media (max-width: 782px) {
+	.eo-lp-editor-grid {
+		grid-template-columns: 1fr;
+	}
+}
+
+.eo-lp-editor-col-left {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.eo-lp-editor-col-right {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	background: #f8fafc;
+	padding: 20px;
+	border-radius: 8px;
+	border: 1px solid #e2e8f0;
+}
+
+/* Form Styles */
+.eo-lp-form-group {
+	display: flex;
+	flex-direction: column;
+}
+
+.eo-lp-form-group label {
+	font-weight: 600;
+	font-size: 13px;
+	color: #334155;
+	margin-bottom: 6px;
+}
+
+.eo-lp-form-group input[type="text"],
+.eo-lp-form-group textarea,
+.eo-lp-form-group select {
+	border: 1px solid #cbd5e1;
+	border-radius: 6px;
+	padding: 8px 12px;
+	font-size: 13px;
+	background-color: #ffffff;
+	transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.eo-lp-form-group input[type="text"]:focus,
+.eo-lp-form-group textarea:focus,
+.eo-lp-form-group select:focus {
+	border-color: #3b82f6;
+	box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+	outline: none;
+}
+
+.eo-lp-color-picker-wrapper {
+	display: flex;
+	align-items: center;
+}
+
+/* Form Footer */
+.eo-lp-editor-footer {
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	background: #f8fafc;
+	border-top: 1px solid #e2e8f0;
+	padding: 16px 24px;
+	gap: 12px;
+}
+
+.eo-lp-editor-status-text {
+	margin-right: auto;
+	font-size: 13px;
+	font-weight: 600;
+	transition: color 0.3s;
+}
+
+/* Keyframes */
+@keyframes slideDown {
+	from {
+		opacity: 0;
+		transform: translateY(-10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}

--- a/assets/js/landing-pages-admin.js
+++ b/assets/js/landing-pages-admin.js
@@ -1,0 +1,248 @@
+/**
+ * JavaScript for EO Blocks - Landing Pages admin interface
+ */
+
+jQuery(document).ready(function($) {
+	// Reference to global config config object
+	var config = window.eoLandingPagesConfig || {};
+	var activeType = '';
+
+	// Sync color picker with text inputs
+	function bindColorPicker(pickerId, textId) {
+		$(pickerId).on('input', function() {
+			$(textId).val($(this).val().toUpperCase());
+			showFormDirty();
+		});
+		$(textId).on('input', function() {
+			var val = $(this).val();
+			if (val.match(/^#[0-9A-F]{6}$/i)) {
+				$(pickerId).val(val);
+				showFormDirty();
+			}
+		});
+	}
+
+	bindColorPicker('#eo-lp-form-bg-color', '#eo-lp-form-bg-color-text');
+	bindColorPicker('#eo-lp-form-text-color', '#eo-lp-form-text-color-text');
+	bindColorPicker('#eo-lp-form-accent-color', '#eo-lp-form-accent-color-text');
+
+	// Mark form as dirty when inputs change
+	$('#eo-lp-editor-form input, #eo-lp-editor-form textarea, #eo-lp-editor-form select').on('input change', function() {
+		showFormDirty();
+	});
+
+	function showFormDirty() {
+		$('.eo-lp-editor-status-text')
+			.text('Changements non enregistrés')
+			.css('color', '#2271b1');
+		$('#eo-lp-save-btn')
+			.removeClass('button-disabled')
+			.css('background-color', '#2271b1');
+	}
+
+	function showFormSaving() {
+		$('.eo-lp-editor-status-text')
+			.text('Enregistrement...')
+			.css('color', '#64748b');
+	}
+
+	function showFormSaved(msg) {
+		$('.eo-lp-editor-status-text')
+			.text(msg || 'Enregistré avec succès')
+			.css('color', '#10b981');
+		$('#eo-lp-save-btn').css('background-color', '#cbd5e1'); // grey-out button
+	}
+
+	function showFormError(msg) {
+		$('.eo-lp-editor-status-text')
+			.text(msg || 'Une erreur est survenue')
+			.css('color', '#d63638');
+	}
+
+	// Toggle active switches
+	$('.eo-lp-toggle-checkbox').on('change', function() {
+		var $checkbox = $(this);
+		var $card = $checkbox.closest('.eo-lp-card');
+		var type = $card.data('type');
+		var active = $checkbox.is(':checked');
+		var $label = $checkbox.siblings('.eo-lp-toggle-label');
+
+		// Visual loading state
+		$checkbox.prop('disabled', true);
+		$label.text('MAJ...');
+
+		$.ajax({
+			url: eoLandingPagesAdmin.ajaxUrl,
+			type: 'POST',
+			data: {
+				action: 'eo_save_landing_page_settings',
+				nonce: eoLandingPagesAdmin.nonce,
+				type: type,
+				active: active ? 'true' : 'false',
+				active_toggle: '1'
+			},
+			success: function(response) {
+				$checkbox.prop('disabled', false);
+				if (response.success) {
+					// Update global config object
+					config = response.data.settings;
+					window.eoLandingPagesConfig = config;
+
+					// Visual state updates
+					if (active) {
+						$card.addClass('active');
+						$label.text('ACTIF').addClass('active');
+
+						// Handle mutual exclusion of Coming Soon and Maintenance
+						if (type === 'coming_soon') {
+							var $mCard = $('.eo-lp-card[data-type="maintenance"]');
+							$mCard.removeClass('active');
+							$mCard.find('.eo-lp-toggle-checkbox').prop('checked', false);
+							$mCard.find('.eo-lp-toggle-label').text('INACTIF').removeClass('active');
+						} else if (type === 'maintenance') {
+							var $csCard = $('.eo-lp-card[data-type="coming_soon"]');
+							$csCard.removeClass('active');
+							$csCard.find('.eo-lp-toggle-checkbox').prop('checked', false);
+							$csCard.find('.eo-lp-toggle-label').text('INACTIF').removeClass('active');
+						}
+					} else {
+						$card.removeClass('active');
+						$label.text('INACTIF').removeClass('active');
+					}
+					
+					// If currently editing this page, update form active state
+					if (activeType === type) {
+						showFormSaved('État mis à jour');
+					}
+				} else {
+					$checkbox.prop('checked', !active); // revert
+					$label.text(active ? 'INACTIF' : 'ACTIF');
+					alert(response.data.message || 'Erreur lors de la modification de l\'état.');
+				}
+			},
+			error: function() {
+				$checkbox.prop('disabled', false);
+				$checkbox.prop('checked', !active); // revert
+				$label.text(active ? 'INACTIF' : 'ACTIF');
+				alert('Impossible de contacter le serveur.');
+			}
+		});
+	});
+
+	// Click Edit Button
+	$('.eo-lp-edit-btn').on('click', function() {
+		var type = $(this).data('type');
+		openEditor(type);
+	});
+
+	function openEditor(type) {
+		activeType = type;
+		var pageConfig = config[type] || {};
+		
+		// Fill form fields
+		$('#eo-lp-form-type').val(type);
+		$('#eo-lp-form-title').val(pageConfig.title || '');
+		$('#eo-lp-form-description').val(pageConfig.description || '');
+		$('#eo-lp-form-style').val(pageConfig.style || 'minimalist');
+
+		// Set color pickers and text values
+		$('#eo-lp-form-bg-color').val(pageConfig.bg_color || '#000000');
+		$('#eo-lp-form-bg-color-text').val((pageConfig.bg_color || '#000000').toUpperCase());
+
+		$('#eo-lp-form-text-color').val(pageConfig.text_color || '#ffffff');
+		$('#eo-lp-form-text-color-text').val((pageConfig.text_color || '#ffffff').toUpperCase());
+
+		$('#eo-lp-form-accent-color').val(pageConfig.accent_color || '#0066FF');
+		$('#eo-lp-form-accent-color-text').val((pageConfig.accent_color || '#0066FF').toUpperCase());
+
+		// Toggle custom hints depending on type
+		$('.eo-lp-form-login-hint').toggle(type === 'login');
+		$('.eo-lp-form-404-hint').toggle(type === '404');
+
+		// Update panel title icon and text
+		var card = $('.eo-lp-card[data-type="' + type + '"]');
+		var cardIconClass = card.find('.eo-lp-card-icon').attr('class').replace('eo-lp-card-icon', '').trim();
+		var cardTitle = card.find('.eo-lp-card-title').text();
+
+		$('.eo-lp-editor-icon').attr('class', 'dashicons eo-lp-editor-icon ' + cardIconClass);
+		$('.eo-lp-editor-title-text').text('Configuration - ' + cardTitle);
+
+		// Style edit button preview
+		var previewUrl = config.homeUrl + '?eo_preview_landing_page=' + type;
+		$('.eo-lp-form-preview-btn').attr('href', previewUrl);
+
+		// Clear status text
+		$('.eo-lp-editor-status-text').text('');
+		$('#eo-lp-save-btn').css('background-color', '#2271b1'); // reset color
+
+		// Scroll to panel and display it
+		$('.eo-lp-editor-panel').slideDown(300, function() {
+			$('html, body').animate({
+				scrollTop: $('.eo-lp-editor-panel').offset().top - 50
+			}, 400);
+		});
+	}
+
+	// Close Panel Button
+	$('.eo-lp-editor-close-btn').on('click', function() {
+		$('.eo-lp-editor-panel').slideUp(300);
+		activeType = '';
+	});
+
+	// Form Submission (Save Settings)
+	$('#eo-lp-editor-form').on('submit', function(e) {
+		e.preventDefault();
+		if (!activeType) return;
+
+		showFormSaving();
+
+		var formData = {
+			action: 'eo_save_landing_page_settings',
+			nonce: eoLandingPagesAdmin.nonce,
+			type: activeType,
+			title: $('#eo-lp-form-title').val(),
+			description: $('#eo-lp-form-description').val(),
+			style: $('#eo-lp-form-style').val(),
+			bg_color: $('#eo-lp-form-bg-color').val(),
+			text_color: $('#eo-lp-form-text-color').val(),
+			accent_color: $('#eo-lp-form-accent-color').val(),
+			active: $('.eo-lp-card[data-type="' + activeType + '"] .eo-lp-toggle-checkbox').is(':checked') ? 'true' : 'false'
+		};
+
+		$.ajax({
+			url: eoLandingPagesAdmin.ajaxUrl,
+			type: 'POST',
+			data: formData,
+			success: function(response) {
+				if (response.success) {
+					// Update global config object
+					config = response.data.settings;
+					window.eoLandingPagesConfig = config;
+
+					// Visual state updates
+					showFormSaved('Paramètres enregistrés avec succès !');
+
+					// Check if Coming Soon or Maintenance was turned off because of mutual exclusion
+					if (formData.active === 'true') {
+						if (activeType === 'coming_soon') {
+							var $mCard = $('.eo-lp-card[data-type="maintenance"]');
+							$mCard.removeClass('active');
+							$mCard.find('.eo-lp-toggle-checkbox').prop('checked', false);
+							$mCard.find('.eo-lp-toggle-label').text('INACTIF').removeClass('active');
+						} else if (activeType === 'maintenance') {
+							var $csCard = $('.eo-lp-card[data-type="coming_soon"]');
+							$csCard.removeClass('active');
+							$csCard.find('.eo-lp-toggle-checkbox').prop('checked', false);
+							$csCard.find('.eo-lp-toggle-label').text('INACTIF').removeClass('active');
+						}
+					}
+				} else {
+					showFormError(response.data.message || 'Erreur lors de l\'enregistrement.');
+				}
+			},
+			error: function() {
+				showFormError('Impossible de contacter le serveur.');
+			}
+		});
+	});
+});

--- a/assets/js/landing-pages-admin.js
+++ b/assets/js/landing-pages-admin.js
@@ -135,6 +135,36 @@ jQuery(document).ready(function($) {
 		openEditor(type);
 	});
 
+	// Change labels dynamically based on selected style and type
+	function adjustFieldLabels() {
+		var style = $('#eo-lp-form-style').val();
+		var type = $('#eo-lp-form-type').val();
+		
+		var $accentGroup = $('#eo-lp-form-accent-color').closest('.eo-lp-form-group');
+		var $accentLabel = $accentGroup.find('label');
+
+		if (style === 'minimalist') {
+			// Minimalist style uses accent color for buttons (Login and 404 only)
+			if (type === 'coming_soon' || type === 'maintenance') {
+				// No buttons on Coming Soon / Maintenance in minimalist style
+				$accentGroup.hide();
+			} else {
+				$accentGroup.show();
+				$accentLabel.text('Couleur du bouton');
+			}
+		} else if (style === 'gradient') {
+			$accentGroup.show();
+			$accentLabel.text('Couleur de fin du dégradé');
+		} else if (style === 'glassmorphism') {
+			$accentGroup.show();
+			$accentLabel.text('Couleur secondaire (Effet verre)');
+		}
+	}
+
+	$('#eo-lp-form-style').on('change', function() {
+		adjustFieldLabels();
+	});
+
 	function openEditor(type) {
 		activeType = type;
 		var pageConfig = config[type] || {};
@@ -154,6 +184,9 @@ jQuery(document).ready(function($) {
 
 		$('#eo-lp-form-accent-color').val(pageConfig.accent_color || '#0066FF');
 		$('#eo-lp-form-accent-color-text').val((pageConfig.accent_color || '#0066FF').toUpperCase());
+
+		// Adjust fields display and labels
+		adjustFieldLabels();
 
 		// Toggle custom hints depending on type
 		$('.eo-lp-form-login-hint').toggle(type === 'login');

--- a/assets/js/landing-pages-admin.js
+++ b/assets/js/landing-pages-admin.js
@@ -7,6 +7,48 @@ jQuery(document).ready(function($) {
 	var config = window.eoLandingPagesConfig || {};
 	var activeType = '';
 
+	// Dynamically update the admin bar status badge
+	function updateAdminBarBadge(settings) {
+		if (typeof eoLandingPagesAdmin === 'undefined') {
+			return;
+		}
+
+		var csActive = settings.coming_soon && (settings.coming_soon.active === true || settings.coming_soon.active === 'true' || settings.coming_soon.active === 1 || settings.coming_soon.active === '1');
+		var mActive = settings.maintenance && (settings.maintenance.active === true || settings.maintenance.active === 'true' || settings.maintenance.active === 1 || settings.maintenance.active === '1');
+
+		var $adminBarSecondary = $('#wp-admin-bar-top-secondary');
+		var $badge = $('#wp-admin-bar-eo-landing-pages-status');
+
+		if (!csActive && !mActive) {
+			$badge.remove();
+			return;
+		}
+
+		var label = '';
+		var badgeClass = 'eo-landing-pages-alert-badge';
+
+		if (csActive && mActive) {
+			label = eoLandingPagesAdmin.labels.both;
+			badgeClass += ' eo-alert-red';
+		} else if (csActive) {
+			label = eoLandingPagesAdmin.labels.coming_soon;
+			badgeClass += ' eo-alert-orange';
+		} else {
+			label = eoLandingPagesAdmin.labels.maintenance;
+			badgeClass += ' eo-alert-red';
+		}
+
+		if ($badge.length === 0) {
+			var html = '<li id="wp-admin-bar-eo-landing-pages-status" class="' + badgeClass + '">' +
+				'<a class="ab-item" href="' + eoLandingPagesAdmin.adminUrl + '">' + label + '</a>' +
+				'</li>';
+			$adminBarSecondary.prepend(html);
+		} else {
+			$badge.attr('class', badgeClass);
+			$badge.find('> .ab-item').text(label);
+		}
+	}
+
 	// Sync color picker with text inputs
 	function bindColorPicker(pickerId, textId) {
 		$(pickerId).on('input', function() {
@@ -65,7 +107,7 @@ jQuery(document).ready(function($) {
 		var $card = $checkbox.closest('.eo-lp-card');
 		var type = $card.data('type');
 		var active = $checkbox.is(':checked');
-		var $label = $checkbox.siblings('.eo-lp-toggle-label');
+		var $label = $checkbox.closest('.eo-lp-toggle-wrapper').find('.eo-lp-toggle-label');
 
 		// Visual loading state
 		$checkbox.prop('disabled', true);
@@ -87,6 +129,9 @@ jQuery(document).ready(function($) {
 					// Update global config object
 					config = response.data.settings;
 					window.eoLandingPagesConfig = config;
+
+					// Dynamically update the admin bar status badge
+					updateAdminBarBadge(config);
 
 					// Visual state updates
 					if (active) {
@@ -251,6 +296,9 @@ jQuery(document).ready(function($) {
 					// Update global config object
 					config = response.data.settings;
 					window.eoLandingPagesConfig = config;
+
+					// Dynamically update the admin bar status badge
+					updateAdminBarBadge(config);
 
 					// Visual state updates
 					showFormSaved('Paramètres enregistrés avec succès !');

--- a/eo-blocks.php
+++ b/eo-blocks.php
@@ -31,6 +31,7 @@ require_once EO_BLOCKS_PATH . '/includes/autoload.php';
 // Load AJAX API endpoints
 require_once EO_BLOCKS_PATH . '/includes/api-eo-search.php';
 require_once EO_BLOCKS_PATH . '/includes/api-eo-maps.php';
+require_once EO_BLOCKS_PATH . '/includes/api-eo-landing-pages.php';
 
 use EoBlocks\Includes\Eoblocks;
 

--- a/includes/admin/class-eoblocks-menu.php
+++ b/includes/admin/class-eoblocks-menu.php
@@ -80,8 +80,14 @@ class Eoblocks_Menu {
 			wp_enqueue_script( 'eo-blocks-landing-pages-admin-js', EO_BLOCKS_URL . 'assets/js/landing-pages-admin.js', array( 'jquery' ), time(), true );
 
 			wp_localize_script( 'eo-blocks-landing-pages-admin-js', 'eoLandingPagesAdmin', array(
-				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'eo_landing_pages_admin_nonce' ),
+				'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'eo_landing_pages_admin_nonce' ),
+				'adminUrl' => admin_url( 'admin.php?page=eo-blocks-landing-pages' ),
+				'labels'   => array(
+					'both'        => __( 'Modes Prochainement & Maintenance actifs', 'eo-blocks' ),
+					'coming_soon' => __( 'Mode Prochainement actif', 'eo-blocks' ),
+					'maintenance' => __( 'Mode Maintenance actif', 'eo-blocks' ),
+				),
 			) );
 			return;
 		}

--- a/includes/admin/class-eoblocks-menu.php
+++ b/includes/admin/class-eoblocks-menu.php
@@ -76,8 +76,8 @@ class Eoblocks_Menu {
 
 	public function enqueue_admin_assets( $hook ) {
 		if ( strpos( $hook, 'eo-blocks-landing-pages' ) !== false ) {
-			wp_enqueue_style( 'eo-blocks-landing-pages-admin-css', EO_BLOCKS_URL . 'assets/css/landing-pages-admin.css', array(), '1.0.0' );
-			wp_enqueue_script( 'eo-blocks-landing-pages-admin-js', EO_BLOCKS_URL . 'assets/js/landing-pages-admin.js', array( 'jquery' ), '1.0.0', true );
+			wp_enqueue_style( 'eo-blocks-landing-pages-admin-css', EO_BLOCKS_URL . 'assets/css/landing-pages-admin.css', array(), time() );
+			wp_enqueue_script( 'eo-blocks-landing-pages-admin-js', EO_BLOCKS_URL . 'assets/js/landing-pages-admin.js', array( 'jquery' ), time(), true );
 
 			wp_localize_script( 'eo-blocks-landing-pages-admin-js', 'eoLandingPagesAdmin', array(
 				'ajaxUrl' => admin_url( 'admin-ajax.php' ),

--- a/includes/admin/class-eoblocks-menu.php
+++ b/includes/admin/class-eoblocks-menu.php
@@ -43,6 +43,16 @@ class Eoblocks_Menu {
 			[ $this, 'maps_page_view' ]
 		);
 
+		// Submenu pointing to Landing Pages manager
+		add_submenu_page(
+			'eo-blocks-maps',
+			__('Pages d\'atterrissage', 'eo-blocks'),
+			__('Pages d\'atterrissage', 'eo-blocks'),
+			'manage_options',
+			'eo-blocks-landing-pages',
+			[ $this, 'landing_pages_page_view' ]
+		);
+
 		// Submenu pointing to general settings
 		add_submenu_page(
 			'eo-blocks-maps',
@@ -65,6 +75,17 @@ class Eoblocks_Menu {
 	}
 
 	public function enqueue_admin_assets( $hook ) {
+		if ( strpos( $hook, 'eo-blocks-landing-pages' ) !== false ) {
+			wp_enqueue_style( 'eo-blocks-landing-pages-admin-css', EO_BLOCKS_URL . 'assets/css/landing-pages-admin.css', array(), '1.0.0' );
+			wp_enqueue_script( 'eo-blocks-landing-pages-admin-js', EO_BLOCKS_URL . 'assets/js/landing-pages-admin.js', array( 'jquery' ), '1.0.0', true );
+
+			wp_localize_script( 'eo-blocks-landing-pages-admin-js', 'eoLandingPagesAdmin', array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'eo_landing_pages_admin_nonce' ),
+			) );
+			return;
+		}
+
 		if ( 'toplevel_page_eo-blocks-maps' !== $hook ) {
 			return;
 		}
@@ -89,6 +110,10 @@ class Eoblocks_Menu {
 
 	public function maps_page_view() {
 		include EO_BLOCKS_PATH . '/includes/admin/views/html-admin-page-maps.php';
+	}
+
+	public function landing_pages_page_view() {
+		include EO_BLOCKS_PATH . '/includes/admin/views/html-admin-page-landing-pages.php';
 	}
 
 	public function settings_page_view() {

--- a/includes/admin/views/html-admin-page-landing-pages.php
+++ b/includes/admin/views/html-admin-page-landing-pages.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Landing Pages management admin view.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$settings = get_option( 'eo_landing_pages_settings', array() );
+
+$defaults = array(
+	'coming_soon' => array(
+		'active'       => false,
+		'title'        => __( 'Bientôt disponible', 'eo-blocks' ),
+		'description' => __( 'Notre nouveau site est en cours de création. Restez à l\'écoute !', 'eo-blocks' ),
+		'style'       => 'minimalist',
+		'bg_color'    => '#0f172a',
+		'text_color'  => '#f8fafc',
+		'accent_color'=> '#3b82f6',
+	),
+	'maintenance' => array(
+		'active'       => false,
+		'title'        => __( 'Site en maintenance', 'eo-blocks' ),
+		'description' => __( 'Nous effectuons actuellement des opérations de maintenance. Nous serons de retour très rapidement.', 'eo-blocks' ),
+		'style'       => 'gradient',
+		'bg_color'    => '#1e1b4b',
+		'text_color'  => '#f8fafc',
+		'accent_color'=> '#6366f1',
+	),
+	'login' => array(
+		'active'       => false,
+		'title'        => __( 'Connexion', 'eo-blocks' ),
+		'description' => __( 'Veuillez vous connecter pour accéder au site.', 'eo-blocks' ),
+		'style'       => 'glassmorphism',
+		'bg_color'    => '#0f172a',
+		'text_color'  => '#f8fafc',
+		'accent_color'=> '#06b6d4',
+	),
+	'404' => array(
+		'active'       => false,
+		'title'        => __( 'Page non trouvée', 'eo-blocks' ),
+		'description' => __( 'Désolé, la page que vous recherchez n\'existe pas ou a été déplacée.', 'eo-blocks' ),
+		'style'       => 'minimalist',
+		'bg_color'    => '#0f172a',
+		'text_color'  => '#f8fafc',
+		'accent_color'=> '#ef4444',
+	),
+);
+
+$coming_soon = isset( $settings['coming_soon'] ) ? array_merge( $defaults['coming_soon'], $settings['coming_soon'] ) : $defaults['coming_soon'];
+$maintenance = isset( $settings['maintenance'] ) ? array_merge( $defaults['maintenance'], $settings['maintenance'] ) : $defaults['maintenance'];
+$login       = isset( $settings['login'] ) ? array_merge( $defaults['login'], $settings['login'] ) : $defaults['login'];
+$status_404  = isset( $settings['404'] ) ? array_merge( $defaults['404'], $settings['404'] ) : $defaults['404'];
+
+$pages_data = array(
+	'coming_soon' => array(
+		'title'       => __( 'Mode Prochainement', 'eo-blocks' ),
+		'desc'        => __( 'La page Prochainement sera accessible aux visiteurs à la place du site en cours de construction.', 'eo-blocks' ),
+		'icon'        => 'dashicons-clock',
+		'config'      => $coming_soon,
+		'color_class' => 'eo-status-coming-soon',
+	),
+	'maintenance' => array(
+		'title'       => __( 'Mode Maintenance', 'eo-blocks' ),
+		'desc'        => __( 'La page de Maintenance informera les visiteurs et les moteurs de recherche que le site est temporairement indisponible.', 'eo-blocks' ),
+		'icon'        => 'dashicons-admin-tools',
+		'config'      => $maintenance,
+		'color_class' => 'eo-status-maintenance',
+	),
+	'login' => array(
+		'title'       => __( 'Page de connexion', 'eo-blocks' ),
+		'desc'        => __( 'Remplacez la page de connexion par défaut (wp-login.php) par un écran de connexion moderne et personnalisé.', 'eo-blocks' ),
+		'icon'        => 'dashicons-lock',
+		'config'      => $login,
+		'color_class' => 'eo-status-login',
+	),
+	'404' => array(
+		'title'       => __( 'Page 404', 'eo-blocks' ),
+		'desc'        => __( 'Personnalisez la page d\'erreur 404 (Page non trouvée) affichée lorsque les visiteurs tentent d\'accéder à une URL brisée.', 'eo-blocks' ),
+		'icon'        => 'dashicons-warning',
+		'config'      => $status_404,
+		'color_class' => 'eo-status-404',
+	),
+);
+?>
+
+<div class="wrap eo-landing-pages-admin-wrapper">
+	<h1 class="wp-heading-inline"><?php esc_html_e( 'EO Blocks - Pages d\'atterrissage', 'eo-blocks' ); ?></h1>
+	<p class="description" style="margin: 8px 0 20px 0; font-size: 14px;">
+		<?php esc_html_e( 'Contrôlez ce que voient vos visiteurs lorsque votre site est en construction, en maintenance, ou lorsqu\'ils rencontrent des erreurs.', 'eo-blocks' ); ?>
+	</p>
+	<hr class="wp-header-end">
+
+	<!-- Grille des modes de pages -->
+	<div class="eo-lp-grid">
+		<?php foreach ( $pages_data as $key => $page ) : ?>
+			<?php 
+				$is_active = !empty( $page['config']['active'] ); 
+				$preview_url = add_query_arg( 'eo_preview_landing_page', $key, home_url() );
+			?>
+			<div class="eo-lp-card <?php echo esc_attr( $page['color_class'] ); ?> <?php echo $is_active ? 'active' : ''; ?>" data-type="<?php echo esc_attr( $key ); ?>">
+				<div class="eo-lp-card-header">
+					<span class="dashicons <?php echo esc_attr( $page['icon'] ); ?> eo-lp-card-icon"></span>
+					<div class="eo-lp-toggle-wrapper">
+						<label class="eo-lp-switch">
+							<input type="checkbox" class="eo-lp-toggle-checkbox" <?php checked( $is_active ); ?> />
+							<span class="eo-lp-slider"></span>
+						</label>
+						<span class="eo-lp-toggle-label <?php echo $is_active ? 'active' : ''; ?>">
+							<?php echo $is_active ? esc_html__( 'ACTIF', 'eo-blocks' ) : esc_html__( 'INACTIF', 'eo-blocks' ); ?>
+						</span>
+					</div>
+				</div>
+				<div class="eo-lp-card-body">
+					<h3 class="eo-lp-card-title"><?php echo esc_html( $page['title'] ); ?></h3>
+					<p class="eo-lp-card-desc"><?php echo esc_html( $page['desc'] ); ?></p>
+				</div>
+				<div class="eo-lp-card-footer">
+					<button type="button" class="button button-primary eo-lp-edit-btn" data-type="<?php echo esc_attr( $key ); ?>">
+						<?php esc_html_e( 'Modifier la page', 'eo-blocks' ); ?>
+					</button>
+					<a href="<?php echo esc_url( $preview_url ); ?>" target="_blank" class="button button-secondary eo-lp-preview-btn">
+						<?php esc_html_e( 'Prévisualisation', 'eo-blocks' ); ?>
+					</a>
+				</div>
+			</div>
+		<?php endforeach; ?>
+	</div>
+
+	<!-- Panneau d'édition des pages -->
+	<div class="eo-lp-editor-panel" style="display: none;">
+		<div class="eo-lp-editor-header">
+			<h2 class="eo-lp-editor-title">
+				<span class="dashicons eo-lp-editor-icon"></span>
+				<span class="eo-lp-editor-title-text"><?php esc_html_e( 'Configuration', 'eo-blocks' ); ?></span>
+			</h2>
+			<button type="button" class="eo-lp-editor-close-btn">&times;</button>
+		</div>
+		
+		<form id="eo-lp-editor-form" method="post">
+			<input type="hidden" name="type" id="eo-lp-form-type" value="" />
+			
+			<div class="eo-lp-editor-grid">
+				<!-- Colonne de gauche : contenu -->
+				<div class="eo-lp-editor-col-left">
+					<div class="eo-lp-form-group">
+						<label for="eo-lp-form-title"><?php esc_html_e( 'Titre principal', 'eo-blocks' ); ?></label>
+						<input type="text" id="eo-lp-form-title" name="title" class="regular-text" style="width: 100%;" required />
+						<p class="description"><?php esc_html_e( 'S\'affiche comme titre majeur sur la page.', 'eo-blocks' ); ?></p>
+					</div>
+
+					<div class="eo-lp-form-group">
+						<label for="eo-lp-form-description"><?php esc_html_e( 'Texte / Description', 'eo-blocks' ); ?></label>
+						<textarea id="eo-lp-form-description" name="description" rows="6" style="width: 100%; font-family: sans-serif;" required></textarea>
+						<p class="description"><?php esc_html_e( 'Description ou informations affichées sous le titre (accepte le code HTML basique).', 'eo-blocks' ); ?></p>
+					</div>
+					
+					<div class="eo-lp-form-group eo-lp-form-login-hint" style="display: none; background: #e0f2fe; color: #0369a1; padding: 12px; border-radius: 6px; border-left: 4px solid #0284c7;">
+						<span class="dashicons dashicons-info" style="vertical-align: middle; margin-right: 4px;"></span>
+						<?php esc_html_e( 'Le formulaire de connexion standard WordPress sécurisé sera automatiquement intégré en dessous du texte.', 'eo-blocks' ); ?>
+					</div>
+
+					<div class="eo-lp-form-group eo-lp-form-404-hint" style="display: none; background: #fee2e2; color: #b91c1c; padding: 12px; border-radius: 6px; border-left: 4px solid #ef4444;">
+						<span class="dashicons dashicons-info" style="vertical-align: middle; margin-right: 4px;"></span>
+						<?php esc_html_e( 'Un bouton "Retour à l\'accueil" redirigeant vers le site sera automatiquement affiché en dessous du texte.', 'eo-blocks' ); ?>
+					</div>
+				</div>
+
+				<!-- Colonne de droite : Design & Style -->
+				<div class="eo-lp-editor-col-right">
+					<div class="eo-lp-form-group">
+						<label for="eo-lp-form-style"><?php esc_html_e( 'Style esthétique', 'eo-blocks' ); ?></label>
+						<select id="eo-lp-form-style" name="style" style="width: 100%; height: 35px;">
+							<option value="minimalist"><?php esc_html_e( 'Minimaliste Moderne', 'eo-blocks' ); ?></option>
+							<option value="gradient"><?php esc_html_e( 'Dégradé Premium', 'eo-blocks' ); ?></option>
+							<option value="glassmorphism"><?php esc_html_e( 'Effet Verre (Glassmorphism)', 'eo-blocks' ); ?></option>
+						</select>
+					</div>
+
+					<div class="eo-lp-form-group">
+						<label for="eo-lp-form-bg-color"><?php esc_html_e( 'Couleur d\'arrière-plan', 'eo-blocks' ); ?></label>
+						<div class="eo-lp-color-picker-wrapper">
+							<input type="color" id="eo-lp-form-bg-color" name="bg_color" style="height: 35px; width: 60px; padding: 0; cursor: pointer; border: 1px solid #ccd0d4;" />
+							<input type="text" id="eo-lp-form-bg-color-text" class="small-text" style="height: 35px; width: 100px; margin-left: 10px; font-family: monospace; text-transform: uppercase;" />
+						</div>
+					</div>
+
+					<div class="eo-lp-form-group">
+						<label for="eo-lp-form-text-color"><?php esc_html_e( 'Couleur du texte', 'eo-blocks' ); ?></label>
+						<div class="eo-lp-color-picker-wrapper">
+							<input type="color" id="eo-lp-form-text-color" name="text_color" style="height: 35px; width: 60px; padding: 0; cursor: pointer; border: 1px solid #ccd0d4;" />
+							<input type="text" id="eo-lp-form-text-color-text" class="small-text" style="height: 35px; width: 100px; margin-left: 10px; font-family: monospace; text-transform: uppercase;" />
+						</div>
+					</div>
+
+					<div class="eo-lp-form-group">
+						<label for="eo-lp-form-accent-color"><?php esc_html_e( 'Couleur d\'accentuation (Boutons / Détails)', 'eo-blocks' ); ?></label>
+						<div class="eo-lp-color-picker-wrapper">
+							<input type="color" id="eo-lp-form-accent-color" name="accent_color" style="height: 35px; width: 60px; padding: 0; cursor: pointer; border: 1px solid #ccd0d4;" />
+							<input type="text" id="eo-lp-form-accent-color-text" class="small-text" style="height: 35px; width: 100px; margin-left: 10px; font-family: monospace; text-transform: uppercase;" />
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Pied de formulaire -->
+			<div class="eo-lp-editor-footer">
+				<div class="eo-lp-editor-status-text"></div>
+				<button type="submit" id="eo-lp-save-btn" class="button button-primary button-large">
+					<?php esc_html_e( 'Enregistrer les paramètres', 'eo-blocks' ); ?>
+				</button>
+				<button type="button" class="button button-secondary button-large eo-lp-form-preview-btn" target="_blank">
+					<?php esc_html_e( 'Prévisualiser', 'eo-blocks' ); ?>
+				</button>
+			</div>
+		</form>
+	</div>
+</div>
+
+<script type="text/javascript">
+	// Local data configuration passed to JS
+	window.eoLandingPagesConfig = <?php echo json_encode( array(
+		'coming_soon' => $coming_soon,
+		'maintenance' => $maintenance,
+		'login'       => $login,
+		'404'         => $status_404,
+		'homeUrl'     => home_url(),
+	) ); ?>;
+</script>

--- a/includes/admin/views/html-admin-page-landing-pages.php
+++ b/includes/admin/views/html-admin-page-landing-pages.php
@@ -17,7 +17,7 @@ $defaults = array(
 		'style'       => 'minimalist',
 		'bg_color'    => '#0f172a',
 		'text_color'  => '#f8fafc',
-		'accent_color'=> '#3b82f6',
+		'accent_color'=> '#f59e0b',
 	),
 	'maintenance' => array(
 		'active'       => false,
@@ -44,7 +44,7 @@ $defaults = array(
 		'style'       => 'minimalist',
 		'bg_color'    => '#0f172a',
 		'text_color'  => '#f8fafc',
-		'accent_color'=> '#ef4444',
+		'accent_color'=> '#3b82f6',
 	),
 );
 

--- a/includes/api-eo-landing-pages.php
+++ b/includes/api-eo-landing-pages.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * AJAX endpoints for managing landing pages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+add_action( 'wp_ajax_eo_save_landing_page_settings', 'eo_landing_pages_ajax_save_settings' );
+
+function eo_landing_pages_ajax_save_settings() {
+	check_ajax_referer( 'eo_landing_pages_admin_nonce', 'nonce' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( array( 'message' => __( 'Vous n\'avez pas la permission de faire cela.', 'eo-blocks' ) ), 403 );
+	}
+
+	$type = isset( $_POST['type'] ) ? sanitize_text_field( $_POST['type'] ) : '';
+	if ( ! in_array( $type, array( 'coming_soon', 'maintenance', 'login', '404' ) ) ) {
+		wp_send_json_error( array( 'message' => __( 'Type de page invalide.', 'eo-blocks' ) ) );
+	}
+
+	$settings = get_option( 'eo_landing_pages_settings', array() );
+
+	// Toggling active state only (fast toggle from list)
+	if ( isset( $_POST['active_toggle'] ) ) {
+		$active = !empty( $_POST['active'] ) && ( $_POST['active'] === 'true' || $_POST['active'] === '1' );
+		
+		// If turning Coming Soon or Maintenance to ON, make sure the other is turned OFF
+		if ( $active ) {
+			if ( 'coming_soon' === $type ) {
+				$settings['maintenance']['active'] = false;
+			} elseif ( 'maintenance' === $type ) {
+				$settings['coming_soon']['active'] = false;
+			}
+		}
+
+		$settings[$type]['active'] = $active;
+
+		update_option( 'eo_landing_pages_settings', $settings );
+		wp_send_json_success( array(
+			'message'  => __( 'État mis à jour avec succès.', 'eo-blocks' ),
+			'settings' => $settings,
+		) );
+	}
+
+	// Full details save
+	$title        = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+	$description  = isset( $_POST['description'] ) ? wp_kses_post( wp_unslash( $_POST['description'] ) ) : '';
+	$style        = isset( $_POST['style'] ) ? sanitize_text_field( $_POST['style'] ) : 'minimalist';
+	$bg_color     = isset( $_POST['bg_color'] ) ? sanitize_hex_color( $_POST['bg_color'] ) : '';
+	$text_color   = isset( $_POST['text_color'] ) ? sanitize_hex_color( $_POST['text_color'] ) : '';
+	$accent_color = isset( $_POST['accent_color'] ) ? sanitize_hex_color( $_POST['accent_color'] ) : '';
+	$active       = isset( $_POST['active'] ) && ( $_POST['active'] === 'true' || $_POST['active'] === '1' );
+
+	if ( $active ) {
+		if ( 'coming_soon' === $type ) {
+			$settings['maintenance']['active'] = false;
+		} elseif ( 'maintenance' === $type ) {
+			$settings['coming_soon']['active'] = false;
+		}
+	}
+
+	$settings[$type] = array(
+		'active'       => $active,
+		'title'        => $title,
+		'description'  => $description,
+		'style'        => $style,
+		'bg_color'     => $bg_color,
+		'text_color'   => $text_color,
+		'accent_color' => $accent_color,
+	);
+
+	update_option( 'eo_landing_pages_settings', $settings );
+
+	wp_send_json_success( array(
+		'message'  => __( 'Paramètres enregistrés avec succès.', 'eo-blocks' ),
+		'settings' => $settings,
+	) );
+}

--- a/includes/class-eoblocks.php
+++ b/includes/class-eoblocks.php
@@ -325,7 +325,7 @@ class Eoblocks {
 				'style'       => 'minimalist',
 				'bg_color'    => '#0f172a',
 				'text_color'  => '#f8fafc',
-				'accent_color'=> '#3b82f6',
+				'accent_color'=> '#f59e0b',
 			),
 			'maintenance' => array(
 				'title'       => __( 'Site en maintenance', 'eo-blocks' ),
@@ -349,7 +349,7 @@ class Eoblocks {
 				'style'       => 'minimalist',
 				'bg_color'    => '#0f172a',
 				'text_color'  => '#f8fafc',
-				'accent_color'=> '#ef4444',
+				'accent_color'=> '#3b82f6',
 			),
 		);
 
@@ -378,7 +378,7 @@ class Eoblocks {
 				$badge_class .= ' eo-alert-red';
 			} elseif ( $coming_soon_active ) {
 				$label = __( 'Mode Prochainement actif', 'eo-blocks' );
-				$badge_class .= ' eo-alert-blue';
+				$badge_class .= ' eo-alert-orange';
 			} else {
 				$label = __( 'Mode Maintenance actif', 'eo-blocks' );
 				$badge_class .= ' eo-alert-red';
@@ -446,6 +446,13 @@ class Eoblocks {
 				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-red:hover > .ab-item {
 					background-color: #b32424 !important;
 				}
+				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-orange > .ab-item {
+					background-color: #f59e0b !important;
+					animation: eo-orange-pulse 2s infinite;
+				}
+				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-orange:hover > .ab-item {
+					background-color: #d97706 !important;
+				}
 				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-blue > .ab-item {
 					background-color: #3b82f6 !important;
 					animation: eo-blue-pulse 2s infinite;
@@ -457,6 +464,11 @@ class Eoblocks {
 					0% { box-shadow: 0 0 0 0 rgba(214, 54, 56, 0.7); }
 					70% { box-shadow: 0 0 0 6px rgba(214, 54, 56, 0); }
 					100% { box-shadow: 0 0 0 0 rgba(214, 54, 56, 0); }
+				}
+				@keyframes eo-orange-pulse {
+					0% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.7); }
+					70% { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0); }
+					100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0); }
 				}
 				@keyframes eo-blue-pulse {
 					0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7); }

--- a/includes/class-eoblocks.php
+++ b/includes/class-eoblocks.php
@@ -43,6 +43,13 @@ class Eoblocks {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
         add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_custom_block_hooks' ) );
 		add_shortcode( 'eo_map', array( $this, 'render_map_shortcode' ) );
+
+		// Landing pages hooks
+		add_action( 'template_redirect', array( $this, 'intercept_frontend' ) );
+		add_action( 'template_redirect', array( $this, 'intercept_404' ) );
+		add_action( 'login_init', array( $this, 'intercept_login' ) );
+		add_action( 'admin_bar_menu', array( $this, 'add_admin_bar_badge' ), 999 );
+		add_action( 'wp_login_failed', array( $this, 'login_failed_redirect' ) );
 	}
 
 	/**
@@ -229,5 +236,215 @@ class Eoblocks {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Intercept frontend requests for Maintenance or Coming Soon modes
+	 */
+	public function intercept_frontend() {
+		// Admin bar preview check first
+		if ( current_user_can( 'manage_options' ) && isset( $_GET['eo_preview_landing_page'] ) ) {
+			$type = sanitize_text_field( $_GET['eo_preview_landing_page'] );
+			if ( in_array( $type, array( 'coming_soon', 'maintenance', 'login', '404' ) ) ) {
+				$this->render_landing_page( $type );
+				exit;
+			}
+		}
+
+		// Administrators bypass maintenance and coming soon
+		if ( current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Don't intercept admin panel or standard login actions
+		if ( is_admin() || in_array( $GLOBALS['pagenow'] ?? '', array( 'wp-login.php', 'wp-register.php' ) ) ) {
+			return;
+		}
+
+		$settings = get_option( 'eo_landing_pages_settings', array() );
+		$coming_soon_active = !empty( $settings['coming_soon']['active'] );
+		$maintenance_active = !empty( $settings['maintenance']['active'] );
+
+		// Maintenance has priority
+		if ( $maintenance_active ) {
+			status_header( 503 );
+			$this->render_landing_page( 'maintenance' );
+			exit;
+		} elseif ( $coming_soon_active ) {
+			$this->render_landing_page( 'coming_soon' );
+			exit;
+		}
+	}
+
+	/**
+	 * Intercept 404 requests to display custom 404 page
+	 */
+	public function intercept_404() {
+		if ( is_404() ) {
+			$settings = get_option( 'eo_landing_pages_settings', array() );
+			$status_404_active = !empty( $settings['404']['active'] );
+			if ( $status_404_active ) {
+				status_header( 404 );
+				$this->render_landing_page( '404' );
+				exit;
+			}
+		}
+	}
+
+	/**
+	 * Intercept login page for customization
+	 */
+	public function intercept_login() {
+		$settings = get_option( 'eo_landing_pages_settings', array() );
+		$login_active = !empty( $settings['login']['active'] );
+
+		if ( $login_active && isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
+			$action = isset( $_GET['action'] ) ? $_GET['action'] : 'login';
+			if ( 'login' === $action ) {
+				$this->render_landing_page( 'login' );
+				exit;
+			}
+		}
+	}
+
+	/**
+	 * Render the custom landing page template
+	 * @param string $type Page type: coming_soon, maintenance, login, 404
+	 */
+	public function render_landing_page( $type ) {
+		$settings_all = get_option( 'eo_landing_pages_settings', array() );
+		
+		// Load default values if not configured
+		$defaults = array(
+			'coming_soon' => array(
+				'title'       => __( 'Bientôt disponible', 'eo-blocks' ),
+				'description' => __( 'Notre nouveau site est en cours de création. Restez à l\'écoute !', 'eo-blocks' ),
+				'style'       => 'minimalist',
+				'bg_color'    => '#0f172a',
+				'text_color'  => '#f8fafc',
+				'accent_color'=> '#3b82f6',
+			),
+			'maintenance' => array(
+				'title'       => __( 'Site en maintenance', 'eo-blocks' ),
+				'description' => __( 'Nous effectuons actuellement des opérations de maintenance. Nous serons de retour très rapidement.', 'eo-blocks' ),
+				'style'       => 'gradient',
+				'bg_color'    => '#1e1b4b',
+				'text_color'  => '#f8fafc',
+				'accent_color'=> '#6366f1',
+			),
+			'login' => array(
+				'title'       => __( 'Connexion', 'eo-blocks' ),
+				'description' => __( 'Veuillez vous connecter pour accéder au site.', 'eo-blocks' ),
+				'style'       => 'glassmorphism',
+				'bg_color'    => '#0f172a',
+				'text_color'  => '#f8fafc',
+				'accent_color'=> '#06b6d4',
+			),
+			'404' => array(
+				'title'       => __( 'Page non trouvée', 'eo-blocks' ),
+				'description' => __( 'Désolé, la page que vous recherchez n\'existe pas ou a été déplacée.', 'eo-blocks' ),
+				'style'       => 'minimalist',
+				'bg_color'    => '#0f172a',
+				'text_color'  => '#f8fafc',
+				'accent_color'=> '#ef4444',
+			),
+		);
+
+		$page_settings = isset( $settings_all[$type] ) ? array_merge( $defaults[$type], $settings_all[$type] ) : $defaults[$type];
+
+		// Disable caching
+		nocache_headers();
+
+		include EO_BLOCKS_PATH . '/includes/templates/landing-page-template.php';
+	}
+
+	/**
+	 * Add custom node to admin bar when Coming Soon or Maintenance mode is ON
+	 */
+	public function add_admin_bar_badge( $wp_admin_bar ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$settings = get_option( 'eo_landing_pages_settings', array() );
+		$coming_soon_active = !empty( $settings['coming_soon']['active'] );
+		$maintenance_active = !empty( $settings['maintenance']['active'] );
+
+		if ( $coming_soon_active || $maintenance_active ) {
+			$label = '';
+			if ( $coming_soon_active && $maintenance_active ) {
+				$label = __( 'Modes Prochainement & Maintenance actifs', 'eo-blocks' );
+			} elseif ( $coming_soon_active ) {
+				$label = __( 'Mode Prochainement actif', 'eo-blocks' );
+			} else {
+				$label = __( 'Mode Maintenance actif', 'eo-blocks' );
+			}
+
+			// Add custom styles for the red badge to the head
+			add_action( 'admin_head', function() {
+				echo '<style>
+					#wpadminbar #wp-admin-bar-eo-landing-pages-status > .ab-item {
+						background-color: #d63638 !important;
+						color: #ffffff !important;
+						font-weight: bold !important;
+						border-radius: 4px;
+						margin-top: 4px;
+						height: 22px;
+						line-height: 22px;
+						padding: 0 10px;
+					}
+					#wpadminbar #wp-admin-bar-eo-landing-pages-status:hover > .ab-item {
+						background-color: #b32424 !important;
+						color: #ffffff !important;
+					}
+				</style>';
+			} );
+
+			// Also for frontend admin bar
+			add_action( 'wp_head', function() {
+				echo '<style>
+					#wpadminbar #wp-admin-bar-eo-landing-pages-status > .ab-item {
+						background-color: #d63638 !important;
+						color: #ffffff !important;
+						font-weight: bold !important;
+						border-radius: 4px;
+						margin-top: 4px;
+						height: 22px;
+						line-height: 22px;
+						padding: 0 10px;
+					}
+					#wpadminbar #wp-admin-bar-eo-landing-pages-status:hover > .ab-item {
+						background-color: #b32424 !important;
+						color: #ffffff !important;
+					}
+				</style>';
+			} );
+
+			$wp_admin_bar->add_node( array(
+				'id'    => 'eo-landing-pages-status',
+				'title' => esc_html( $label ),
+				'href'  => admin_url( 'admin.php?page=eo-blocks-landing-pages' ),
+				'meta'  => array(
+					'title' => $label,
+				),
+			) );
+		}
+	}
+
+	/**
+	 * Redirect failed login attempts back to custom login page with error arg
+	 */
+	public function login_failed_redirect( $username ) {
+		$settings = get_option( 'eo_landing_pages_settings', array() );
+		$login_active = !empty( $settings['login']['active'] );
+
+		if ( $login_active ) {
+			$referrer = wp_get_referer();
+			if ( $referrer && strpos( $referrer, 'wp-login.php' ) !== false ) {
+				// Redirect back with login_error flag
+				wp_redirect( add_query_arg( 'login_error', '1', $referrer ) );
+				exit;
+			}
+		}
 	}
 }

--- a/includes/class-eoblocks.php
+++ b/includes/class-eoblocks.php
@@ -360,10 +360,6 @@ class Eoblocks {
 
 		include EO_BLOCKS_PATH . '/includes/templates/landing-page-template.php';
 	}
-
-	/**
-	 * Add custom node to admin bar when Coming Soon or Maintenance mode is ON
-	 */
 	public function add_admin_bar_badge( $wp_admin_bar ) {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
@@ -375,12 +371,17 @@ class Eoblocks {
 
 		if ( $coming_soon_active || $maintenance_active ) {
 			$label = '';
+			$badge_class = 'eo-landing-pages-alert-badge';
+
 			if ( $coming_soon_active && $maintenance_active ) {
 				$label = __( 'Modes Prochainement & Maintenance actifs', 'eo-blocks' );
+				$badge_class .= ' eo-alert-red';
 			} elseif ( $coming_soon_active ) {
 				$label = __( 'Mode Prochainement actif', 'eo-blocks' );
+				$badge_class .= ' eo-alert-blue';
 			} else {
 				$label = __( 'Mode Maintenance actif', 'eo-blocks' );
+				$badge_class .= ' eo-alert-red';
 			}
 
 			$wp_admin_bar->add_node( array(
@@ -390,6 +391,7 @@ class Eoblocks {
 				'href'   => admin_url( 'admin.php?page=eo-blocks-landing-pages' ),
 				'meta'   => array(
 					'title' => $label,
+					'class' => $badge_class,
 				),
 			) );
 		}
@@ -422,8 +424,7 @@ class Eoblocks {
 
 		if ( $coming_soon_active || $maintenance_active ) {
 			echo '<style>
-				#wpadminbar #wp-admin-bar-eo-landing-pages-status > .ab-item {
-					background-color: #d63638 !important;
+				#wpadminbar .eo-landing-pages-alert-badge > .ab-item {
 					color: #ffffff !important;
 					font-weight: bold !important;
 					border-radius: 4px !important;
@@ -432,12 +433,37 @@ class Eoblocks {
 					line-height: 24px !important;
 					padding: 0 10px !important;
 					display: inline-block !important;
+					box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+					transition: background-color 0.25s ease, transform 0.15s ease !important;
 				}
-				#wpadminbar #wp-admin-bar-eo-landing-pages-status:hover > .ab-item {
+				#wpadminbar .eo-landing-pages-alert-badge:hover > .ab-item {
+					transform: scale(1.05);
+				}
+				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-red > .ab-item {
+					background-color: #d63638 !important;
+					animation: eo-red-pulse 2s infinite;
+				}
+				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-red:hover > .ab-item {
 					background-color: #b32424 !important;
-					color: #ffffff !important;
+				}
+				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-blue > .ab-item {
+					background-color: #3b82f6 !important;
+					animation: eo-blue-pulse 2s infinite;
+				}
+				#wpadminbar .eo-landing-pages-alert-badge.eo-alert-blue:hover > .ab-item {
+					background-color: #1d4ed8 !important;
+				}
+				@keyframes eo-red-pulse {
+					0% { box-shadow: 0 0 0 0 rgba(214, 54, 56, 0.7); }
+					70% { box-shadow: 0 0 0 6px rgba(214, 54, 56, 0); }
+					100% { box-shadow: 0 0 0 0 rgba(214, 54, 56, 0); }
+				}
+				@keyframes eo-blue-pulse {
+					0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7); }
+					70% { box-shadow: 0 0 0 6px rgba(59, 130, 246, 0); }
+					100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
 				}
 			</style>';
 		}
 	}
-}
+}

--- a/includes/class-eoblocks.php
+++ b/includes/class-eoblocks.php
@@ -50,6 +50,8 @@ class Eoblocks {
 		add_action( 'login_init', array( $this, 'intercept_login' ) );
 		add_action( 'admin_bar_menu', array( $this, 'add_admin_bar_badge' ), 999 );
 		add_action( 'wp_login_failed', array( $this, 'login_failed_redirect' ) );
+		add_action( 'admin_head', array( $this, 'enqueue_admin_bar_styles' ) );
+		add_action( 'wp_head', array( $this, 'enqueue_admin_bar_styles' ) );
 	}
 
 	/**
@@ -381,51 +383,12 @@ class Eoblocks {
 				$label = __( 'Mode Maintenance actif', 'eo-blocks' );
 			}
 
-			// Add custom styles for the red badge to the head
-			add_action( 'admin_head', function() {
-				echo '<style>
-					#wpadminbar #wp-admin-bar-eo-landing-pages-status > .ab-item {
-						background-color: #d63638 !important;
-						color: #ffffff !important;
-						font-weight: bold !important;
-						border-radius: 4px;
-						margin-top: 4px;
-						height: 22px;
-						line-height: 22px;
-						padding: 0 10px;
-					}
-					#wpadminbar #wp-admin-bar-eo-landing-pages-status:hover > .ab-item {
-						background-color: #b32424 !important;
-						color: #ffffff !important;
-					}
-				</style>';
-			} );
-
-			// Also for frontend admin bar
-			add_action( 'wp_head', function() {
-				echo '<style>
-					#wpadminbar #wp-admin-bar-eo-landing-pages-status > .ab-item {
-						background-color: #d63638 !important;
-						color: #ffffff !important;
-						font-weight: bold !important;
-						border-radius: 4px;
-						margin-top: 4px;
-						height: 22px;
-						line-height: 22px;
-						padding: 0 10px;
-					}
-					#wpadminbar #wp-admin-bar-eo-landing-pages-status:hover > .ab-item {
-						background-color: #b32424 !important;
-						color: #ffffff !important;
-					}
-				</style>';
-			} );
-
 			$wp_admin_bar->add_node( array(
-				'id'    => 'eo-landing-pages-status',
-				'title' => esc_html( $label ),
-				'href'  => admin_url( 'admin.php?page=eo-blocks-landing-pages' ),
-				'meta'  => array(
+				'id'     => 'eo-landing-pages-status',
+				'parent' => 'top-secondary',
+				'title'  => esc_html( $label ),
+				'href'   => admin_url( 'admin.php?page=eo-blocks-landing-pages' ),
+				'meta'   => array(
 					'title' => $label,
 				),
 			) );
@@ -446,6 +409,35 @@ class Eoblocks {
 				wp_redirect( add_query_arg( 'login_error', '1', $referrer ) );
 				exit;
 			}
+		}
+	}
+
+	/**
+	 * Output admin bar badge styles in head
+	 */
+	public function enqueue_admin_bar_styles() {
+		$settings = get_option( 'eo_landing_pages_settings', array() );
+		$coming_soon_active = !empty( $settings['coming_soon']['active'] );
+		$maintenance_active = !empty( $settings['maintenance']['active'] );
+
+		if ( $coming_soon_active || $maintenance_active ) {
+			echo '<style>
+				#wpadminbar #wp-admin-bar-eo-landing-pages-status > .ab-item {
+					background-color: #d63638 !important;
+					color: #ffffff !important;
+					font-weight: bold !important;
+					border-radius: 4px !important;
+					margin-top: 4px !important;
+					height: 24px !important;
+					line-height: 24px !important;
+					padding: 0 10px !important;
+					display: inline-block !important;
+				}
+				#wpadminbar #wp-admin-bar-eo-landing-pages-status:hover > .ab-item {
+					background-color: #b32424 !important;
+					color: #ffffff !important;
+				}
+			</style>';
 		}
 	}
 }

--- a/includes/class-eoblocks.php
+++ b/includes/class-eoblocks.php
@@ -418,12 +418,11 @@ class Eoblocks {
 	 * Output admin bar badge styles in head
 	 */
 	public function enqueue_admin_bar_styles() {
-		$settings = get_option( 'eo_landing_pages_settings', array() );
-		$coming_soon_active = !empty( $settings['coming_soon']['active'] );
-		$maintenance_active = !empty( $settings['maintenance']['active'] );
+		if ( ! is_admin_bar_showing() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-		if ( $coming_soon_active || $maintenance_active ) {
-			echo '<style>
+		echo '<style>
 				#wpadminbar .eo-landing-pages-alert-badge > .ab-item {
 					color: #ffffff !important;
 					font-weight: bold !important;
@@ -476,6 +475,5 @@ class Eoblocks {
 					100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
 				}
 			</style>';
-		}
 	}
 }

--- a/includes/class-eoblocks.php
+++ b/includes/class-eoblocks.php
@@ -291,10 +291,11 @@ class Eoblocks {
 		}
 	}
 
-	/**
-	 * Intercept login page for customization
-	 */
 	public function intercept_login() {
+		if ( is_user_logged_in() || ! empty( $_REQUEST['interim-login'] ) ) {
+			return;
+		}
+
 		$settings = get_option( 'eo_landing_pages_settings', array() );
 		$login_active = !empty( $settings['login']['active'] );
 

--- a/includes/templates/landing-page-template.php
+++ b/includes/templates/landing-page-template.php
@@ -287,9 +287,10 @@ $input_border= $is_light_bg ? 'rgba(0, 0, 0, 0.15)' : 'rgba(255, 255, 255, 0.15)
 				<?php endif; ?>
 
 				<?php
+				$redirect = !empty( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : admin_url();
 				wp_login_form( array(
 					'echo'           => true,
-					'redirect'       => home_url(),
+					'redirect'       => $redirect,
 					'form_id'        => 'eo-loginform',
 					'label_username' => __( 'Identifiant ou E-mail', 'eo-blocks' ),
 					'label_password' => __( 'Mot de passe', 'eo-blocks' ),

--- a/includes/templates/landing-page-template.php
+++ b/includes/templates/landing-page-template.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Dynamic Template for Public Landing Pages (Coming Soon, Maintenance, Login, 404)
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$title        = $page_settings['title'] ?? '';
+$description  = $page_settings['description'] ?? '';
+$style        = $page_settings['style'] ?? 'minimalist';
+$bg_color     = $page_settings['bg_color'] ?? '#0f172a';
+$text_color   = $page_settings['text_color'] ?? '#f8fafc';
+$accent_color = $page_settings['accent_color'] ?? '#3b82f6';
+
+// Determine if the text/bg is light or dark for appropriate contrasts
+$is_light_bg = ( hexdec( substr( $bg_color, 1, 2 ) ) + hexdec( substr( $bg_color, 3, 2 ) ) + hexdec( substr( $bg_color, 5, 2 ) ) ) > 380;
+$card_bg     = $is_light_bg ? 'rgba(255, 255, 255, 0.85)' : 'rgba(15, 23, 42, 0.65)';
+$card_border = $is_light_bg ? 'rgba(0, 0, 0, 0.08)' : 'rgba(255, 255, 255, 0.08)';
+$input_bg    = $is_light_bg ? 'rgba(0, 0, 0, 0.03)' : 'rgba(255, 255, 255, 0.05)';
+$input_border= $is_light_bg ? 'rgba(0, 0, 0, 0.15)' : 'rgba(255, 255, 255, 0.15)';
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><?php echo esc_html( $title ); ?></title>
+	
+	<!-- Load Google Fonts -->
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Outfit:wght@600;700;800&display=swap" rel="stylesheet">
+	
+	<style>
+		/* Core Resets */
+		* {
+			box-sizing: border-box;
+			margin: 0;
+			padding: 0;
+		}
+		
+		body {
+			font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+			background-color: <?php echo esc_html( $bg_color ); ?>;
+			color: <?php echo esc_html( $text_color ); ?>;
+			min-height: 100vh;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			overflow-x: hidden;
+			position: relative;
+			line-height: 1.6;
+		}
+
+		/* Typography */
+		h1 {
+			font-family: 'Outfit', sans-serif;
+			font-size: clamp(2rem, 5vw, 3.5rem);
+			font-weight: 800;
+			line-height: 1.15;
+			margin-bottom: 1rem;
+			color: <?php echo $is_light_bg ? '#0f172a' : '#ffffff'; ?>;
+		}
+
+		p.description {
+			font-size: clamp(1rem, 2.5vw, 1.25rem);
+			color: <?php echo $is_light_bg ? '#475569' : '#94a3b8'; ?>;
+			margin-bottom: 2rem;
+			max-width: 600px;
+			margin-left: auto;
+			margin-right: auto;
+		}
+
+		/* Base Card Container */
+		.eo-lp-container {
+			width: 100%;
+			max-width: 650px;
+			padding: 2.5rem;
+			text-align: center;
+			z-index: 10;
+			position: relative;
+		}
+
+		/* --- Theme Style 1: Minimalist --- */
+		<?php if ( 'minimalist' === $style ) : ?>
+		.eo-lp-box {
+			background: <?php echo $card_bg; ?>;
+			border: 1px solid <?php echo $card_border; ?>;
+			border-radius: 16px;
+			padding: 3.5rem 2.5rem;
+			box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.05);
+		}
+		<?php endif; ?>
+
+		/* --- Theme Style 2: Gradient Background --- */
+		<?php if ( 'gradient' === $style ) : ?>
+		body {
+			background: linear-gradient(135deg, <?php echo esc_html( $bg_color ); ?> 0%, <?php echo esc_html( $accent_color ); ?> 100%);
+		}
+		.eo-lp-box {
+			background: rgba(255, 255, 255, 0.1);
+			border: 1px solid rgba(255, 255, 255, 0.15);
+			backdrop-filter: blur(10px);
+			border-radius: 20px;
+			padding: 3.5rem 2.5rem;
+			box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+		}
+		/* Animated Blobs */
+		.blob {
+			position: absolute;
+			border-radius: 50%;
+			filter: blur(60px);
+			z-index: 1;
+			opacity: 0.4;
+			animation: float 8s infinite alternate ease-in-out;
+		}
+		.blob-1 {
+			width: 300px;
+			height: 300px;
+			background: <?php echo esc_html( $accent_color ); ?>;
+			top: -100px;
+			right: -100px;
+		}
+		.blob-2 {
+			width: 250px;
+			height: 250px;
+			background: <?php echo esc_html( $bg_color ); ?>;
+			bottom: -100px;
+			left: -100px;
+			animation-delay: -3s;
+		}
+		@keyframes float {
+			0% { transform: translateY(0) scale(1); }
+			100% { transform: translateY(20px) scale(1.1); }
+		}
+		<?php endif; ?>
+
+		/* --- Theme Style 3: Glassmorphism --- */
+		<?php if ( 'glassmorphism' === $style ) : ?>
+		body {
+			background-color: #0b0f19;
+			background-image: 
+				radial-gradient(at 10% 20%, <?php echo esc_html( $bg_color ); ?> 0px, transparent 50%),
+				radial-gradient(at 90% 80%, <?php echo esc_html( $accent_color ); ?> 0px, transparent 50%);
+		}
+		.eo-lp-box {
+			background: rgba(15, 23, 42, 0.55);
+			border: 1px solid rgba(255, 255, 255, 0.08);
+			backdrop-filter: blur(20px) saturate(180%);
+			-webkit-backdrop-filter: blur(20px) saturate(180%);
+			border-radius: 24px;
+			padding: 4rem 3rem;
+			box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+		}
+		<?php endif; ?>
+
+		/* Custom Buttons / Actions */
+		.eo-lp-btn {
+			display: inline-block;
+			background-color: <?php echo esc_html( $accent_color ); ?>;
+			color: #ffffff !important;
+			text-decoration: none;
+			padding: 0.75rem 1.75rem;
+			border-radius: 8px;
+			font-weight: 600;
+			font-size: 1rem;
+			transition: filter 0.2s, transform 0.1s;
+			box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+			border: none;
+			cursor: pointer;
+		}
+		.eo-lp-btn:hover {
+			filter: brightness(1.1);
+		}
+		.eo-lp-btn:active {
+			transform: scale(0.98);
+		}
+
+		/* Error notices style */
+		.eo-login-error {
+			background-color: rgba(239, 68, 68, 0.1);
+			color: #ef4444;
+			border: 1px solid rgba(239, 68, 68, 0.2);
+			border-radius: 8px;
+			padding: 10px 14px;
+			margin-bottom: 1.5rem;
+			font-size: 13px;
+			font-weight: 500;
+			text-align: left;
+		}
+
+		/* WordPress Login Form Styling customization */
+		#eo-loginform {
+			text-align: left;
+			margin-top: 1.5rem;
+		}
+		#eo-loginform p {
+			margin-bottom: 1.25rem;
+		}
+		#eo-loginform label {
+			display: block;
+			font-size: 13px;
+			font-weight: 600;
+			margin-bottom: 6px;
+			color: <?php echo $is_light_bg ? '#475569' : '#cbd5e1'; ?>;
+		}
+		#eo-loginform input[type="text"],
+		#eo-loginform input[type="password"] {
+			width: 100%;
+			padding: 0.75rem 1rem;
+			font-size: 14px;
+			background: <?php echo $input_bg; ?>;
+			border: 1px solid <?php echo $input_border; ?>;
+			border-radius: 8px;
+			color: <?php echo $is_light_bg ? '#0f172a' : '#ffffff'; ?>;
+			transition: border-color 0.2s, box-shadow 0.2s;
+		}
+		#eo-loginform input[type="text"]:focus,
+		#eo-loginform input[type="password"]:focus {
+			border-color: <?php echo esc_html( $accent_color ); ?>;
+			box-shadow: 0 0 0 3px <?php echo esc_html( $accent_color ); ?>25;
+			outline: none;
+		}
+		#eo-loginform .login-remember {
+			display: flex;
+			align-items: center;
+		}
+		#eo-loginform .login-remember label {
+			display: flex;
+			align-items: center;
+			cursor: pointer;
+			font-weight: 500;
+			user-select: none;
+		}
+		#eo-loginform .login-remember input[type="checkbox"] {
+			margin-right: 8px;
+			width: 16px;
+			height: 16px;
+			cursor: pointer;
+		}
+		#eo-loginform .login-submit {
+			margin-bottom: 0;
+			margin-top: 1.5rem;
+		}
+		#eo-loginform input[type="submit"] {
+			width: 100%;
+			background-color: <?php echo esc_html( $accent_color ); ?>;
+			color: #ffffff;
+			border: none;
+			padding: 0.75rem;
+			border-radius: 8px;
+			font-size: 15px;
+			font-weight: 600;
+			cursor: pointer;
+			transition: filter 0.2s, transform 0.1s;
+			box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+		}
+		#eo-loginform input[type="submit"]:hover {
+			filter: brightness(1.1);
+		}
+		#eo-loginform input[type="submit"]:active {
+			transform: scale(0.98);
+		}
+	</style>
+</head>
+<body>
+
+	<?php if ( 'gradient' === $style ) : ?>
+		<div class="blob blob-1"></div>
+		<div class="blob blob-2"></div>
+	<?php endif; ?>
+
+	<div class="eo-lp-container">
+		<div class="eo-lp-box">
+			<h1><?php echo esc_html( $title ); ?></h1>
+			<p class="description"><?php echo wp_kses_post( nl2br( $description ) ); ?></p>
+			
+			<?php if ( 'login' === $type ) : ?>
+				
+				<?php if ( isset( $_GET['login_error'] ) ) : ?>
+					<div class="eo-login-error">
+						<span class="dashicons dashicons-warning" style="vertical-align: middle; margin-right: 4px;"></span>
+						<?php esc_html_e( 'Identifiant ou mot de passe incorrect. Veuillez réessayer.', 'eo-blocks' ); ?>
+					</div>
+				<?php endif; ?>
+
+				<?php
+				wp_login_form( array(
+					'echo'           => true,
+					'redirect'       => home_url(),
+					'form_id'        => 'eo-loginform',
+					'label_username' => __( 'Identifiant ou E-mail', 'eo-blocks' ),
+					'label_password' => __( 'Mot de passe', 'eo-blocks' ),
+					'label_remember' => __( 'Se souvenir de moi', 'eo-blocks' ),
+					'label_log_in'   => __( 'Se connecter', 'eo-blocks' ),
+					'remember'       => true,
+					'value_remember' => true,
+				) );
+				?>
+
+			<?php elseif ( '404' === $type ) : ?>
+				<a href="<?php echo esc_url( home_url() ); ?>" class="eo-lp-btn">
+					<?php esc_html_e( 'Retour à l\'accueil', 'eo-blocks' ); ?>
+				</a>
+			<?php endif; ?>
+		</div>
+	</div>
+
+</body>
+</html>


### PR DESCRIPTION
This PR implements the custom landing pages system (Coming Soon, Maintenance, Login, 404), addressing issue #77.

### Key Changes
- **Admin UI**: Grid view of cards representing the 4 states with iOS toggles. Inline configuration panel for setting titles, descriptions, color pickers, and layout style.
- **Interception**: Public frontend requests are intercepted to render the active template (Coming Soon or Maintenance) for non-admins. Custom 404 pages are intercepted to display the styled error layout. Custom login forms are integrated cleanly with `wp_login_form()` and support redirecting login errors back to the custom view.
- **Mutual Exclusion**: If Maintenance is turned on, Coming Soon is deactivated (and vice-versa).
- **Admin Bar Alert**: When Maintenance or Coming Soon is active, a status badge is displayed in the WordPress admin bar for quick awareness (Orange for Coming Soon, Red for Maintenance).
- **Dynamic Updates**: Toggling the modes or saving configurations updates the admin bar status badge and card labels (ACTIF / INACTIF) immediately via AJAX, without requiring a page reload.
- **Esthetics**: 3 premium themes (Minimalist, Gradient, and Glassmorphism) with Outfit/Inter typography, animated background blobs, and mesh gradients.
